### PR TITLE
change baseURL to point to reva subdomain

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -59,7 +59,7 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"          
+            --baseURL "https://blog.tryreva.com/"          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://tryreva.com/'
+baseURL = 'https://blog.tryreva.com/'
 languageCode = 'en-us'
 title = 'Reva'
 theme = 'hermit-v2'


### PR DESCRIPTION
Setting a GH pages site to point to a custom domain broke the styling of the blog as GH disables CORS by default.

This PR just explicitly sets the baseURL in the config, but also made a change in the workflow so it sets it when deploying the stie